### PR TITLE
Allow copy into same account

### DIFF
--- a/aws_ssm_copy/ssm_copy.py
+++ b/aws_ssm_copy/ssm_copy.py
@@ -51,9 +51,6 @@ class ParameterCopier(object):
     def precondition_check(self):
         source_id = self.source_sts.get_caller_identity()
         target_id = self.target_sts.get_caller_identity()
-        if source_id['Account'] == target_id['Account']:
-            sys.stderr.write('ERROR: cannot copy into the same AWS account.\n')
-            sys.exit(1)
 
     def load_source_parameters(self, arg, recursive, one_level):
         result = {}


### PR DESCRIPTION
Copying within an account is all good on my test. I haven't tried between regions but I don't anticipate any issues.

`python ssm_copy.py --recursive --target-path /config/testing2/ /config/testing1/`

> INFO: copying /config/testing1/test1 to /config/testing2/test1
> INFO: copying /config/testing1/test2 to /config/testing2/test2