### PR TITLE
Fix for boto exception during copy

### DIFF
--- a/aws_ssm_copy/copy.py
+++ b/aws_ssm_copy/copy.py
@@ -88,6 +88,10 @@ class ParameterCopier(object):
                     del parameter["LastModifiedUser"]
                 if "Version" in parameter:
                     del parameter["Version"]
+                if "Policies" in parameter:
+                    if not parameter["Policies"]:
+                        # an empty policies list causes an exception
+                        del parameter["Policies"]
                 parameter["Overwrite"] = overwrite
                 parameter = rename_parameter(parameter, arg, self.target_path)
                 sys.stderr.write(


### PR DESCRIPTION
When asking for a parameter, boto3 will append an empty "Policies"
list. When pushed as an argument into "put_parameter" empy lists
cause an exception, as demonstrated in this issue:
https://github.com/binxio/aws-ssm-copy/issues/2