### PR TITLE
Clarify dry-run results vs actual copy

### DIFF
--- a/aws_ssm_copy/copy.py
+++ b/aws_ssm_copy/copy.py
@@ -94,10 +94,14 @@ class ParameterCopier(object):
                         del parameter["Policies"]
                 parameter["Overwrite"] = overwrite
                 parameter = rename_parameter(parameter, arg, self.target_path)
-                sys.stderr.write(
-                    "INFO: copying {} to {}\n".format(name, parameter["Name"])
-                )
-                if not self.dry_run:
+                if self.dry_run:
+                    sys.stdout.write(
+                        "DRY-RUN: copying {} to {}\n".format(name, parameter["Name"])
+                    )                    
+                else:
+                    sys.stdout.write(
+                        "INFO: copying {} to {}\n".format(name, parameter["Name"])
+                    )                    
                     self.target_ssm.put_parameter(**parameter)
 
     def main(self):


### PR DESCRIPTION
I found that running with the `--dry-run` option gives the same output as running without it, which can be confusing. Example:

INFO: copying /prod/db/secret to /qa/db/secret
INFO: copying /prod/db/table to /qa/db/table

The tool gives the impression that it has copied parameters, when in fact it has not because it was just a dry run.

Also, made a minor change to redirect this output to `stdout` rather than `stderr`, as it is not an error.

Very helpful project, thank you!